### PR TITLE
Fix memory access issues

### DIFF
--- a/src/obs-virtualbg-render.cpp
+++ b/src/obs-virtualbg-render.cpp
@@ -40,11 +40,12 @@ void render_destroy(void *data) {
     obs_enter_graphics();
     gs_effect_destroy(filter_data->effect);
     gs_effect_destroy(filter_data->effect2);
+    gs_texture_destroy(filter_data->texture);
+    gs_texture_destroy(filter_data->texture2);
     obs_leave_graphics();
-    bfree(filter_data);
-  }
-  if (filter_data->mask_buffer) {
     bfree(filter_data->mask_buffer);
+    bfree(filter_data->mask_buffer2);
+    bfree(filter_data);
   }
 }
 


### PR DESCRIPTION
This PR fixes two issues.
- `filter_data->mask_buffer` was freed after freeing `filter_data`, which causes read-after-free.
- memory leaks of `filter_data->texture`, `filter_data->texture2`, and `filter_data->mask_buffer2`.

